### PR TITLE
Suppress showing of trailing whitespace in dictionary buffer

### DIFF
--- a/helm-wordnet.el
+++ b/helm-wordnet.el
@@ -100,6 +100,7 @@
   "Display meaning of WORD."
   (let ((buf (get-buffer-create helm-wordnet-buffer)))
     (with-current-buffer buf
+      (setq show-trailing-whitespace nil)
       (read-only-mode -1)
       (erase-buffer)
       (setq cursor-type nil)


### PR DESCRIPTION
Turn off `show-trailing-whitespace` in the dictionary buffer.
